### PR TITLE
Fix: Adaptive banner black space using SafeArea

### DIFF
--- a/lib/src/easy_banner_widget.dart
+++ b/lib/src/easy_banner_widget.dart
@@ -38,7 +38,15 @@ class EasyBannerAd extends StatefulWidget {
   /// Ignored if [adSize] is provided.
   final bool collapsible;
 
-  const EasyBannerAd({super.key, this.adSize, this.collapsible = false});
+  // Optional if user want to use it or not. Default (true)
+  final bool useSafeArea;
+
+  const EasyBannerAd({
+    super.key,
+    this.adSize,
+    this.collapsible = false,
+    this.useSafeArea = true,
+  });
 
   @override
   State<EasyBannerAd> createState() => _EasyBannerAdState();
@@ -239,6 +247,9 @@ class _EasyBannerAdState extends State<EasyBannerAd> {
         _currentOrientation = orientation;
 
         if (!_isLoaded) return const SizedBox.shrink();
+        if (!widget.useSafeArea) {
+          return _bannerManager.buildAdWidget() ?? const SizedBox.shrink();
+        }
         return SafeArea(
           child: _bannerManager.buildAdWidget() ?? const SizedBox.shrink(),
         );

--- a/lib/src/easy_banner_widget.dart
+++ b/lib/src/easy_banner_widget.dart
@@ -38,7 +38,11 @@ class EasyBannerAd extends StatefulWidget {
   /// Ignored if [adSize] is provided.
   final bool collapsible;
 
-  // Optional if user want to use it or not. Default (true)
+  /// Whether to wrap the ad widget in a [SafeArea].
+  ///
+  /// Set to `false` if the banner is already inside a [SafeArea] or
+  /// a [Scaffold] that handles insets, to avoid extra padding/black space.
+  /// Defaults to `true`.
   final bool useSafeArea;
 
   const EasyBannerAd({
@@ -210,6 +214,12 @@ class _EasyBannerAdState extends State<EasyBannerAd> {
     super.dispose();
   }
 
+  /// Wraps [child] in a [SafeArea] when [EasyBannerAd.useSafeArea] is true.
+  Widget _wrapWithSafeArea(Widget child) {
+    if (!widget.useSafeArea) return child;
+    return SafeArea(child: child);
+  }
+
   @override
   Widget build(BuildContext context) {
     // Don't show anything if ads are disabled
@@ -218,8 +228,8 @@ class _EasyBannerAdState extends State<EasyBannerAd> {
     // Fixed size banners don't need orientation handling
     if (widget.adSize != null) {
       if (!_isLoaded) return const SizedBox.shrink();
-      return SafeArea(
-        child: _bannerManager.buildAdWidget() ?? const SizedBox.shrink(),
+      return _wrapWithSafeArea(
+        _bannerManager.buildAdWidget() ?? const SizedBox.shrink(),
       );
     }
 
@@ -247,11 +257,8 @@ class _EasyBannerAdState extends State<EasyBannerAd> {
         _currentOrientation = orientation;
 
         if (!_isLoaded) return const SizedBox.shrink();
-        if (!widget.useSafeArea) {
-          return _bannerManager.buildAdWidget() ?? const SizedBox.shrink();
-        }
-        return SafeArea(
-          child: _bannerManager.buildAdWidget() ?? const SizedBox.shrink(),
+        return _wrapWithSafeArea(
+          _bannerManager.buildAdWidget() ?? const SizedBox.shrink(),
         );
       },
     );

--- a/test/easy_banner_widget_coverage_test.dart
+++ b/test/easy_banner_widget_coverage_test.dart
@@ -212,6 +212,119 @@ void main() {
     });
   });
 
+  group('EasyBannerAd useSafeArea', () {
+    testWidgets('fixed size banner omits SafeArea when useSafeArea is false', (
+      tester,
+    ) async {
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      await AdFlow.instance.initialize();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EasyBannerAd(adSize: AdSize.banner, useSafeArea: false),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // The EasyBannerAd subtree should not contain a SafeArea
+      final easyBannerFinder = find.byType(EasyBannerAd);
+      expect(easyBannerFinder, findsOneWidget);
+      expect(
+        find.descendant(of: easyBannerFinder, matching: find.byType(SafeArea)),
+        findsNothing,
+      );
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('fixed size banner wraps with SafeArea by default', (
+      tester,
+    ) async {
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      await AdFlow.instance.initialize();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: EasyBannerAd(adSize: AdSize.banner)),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final easyBannerFinder = find.byType(EasyBannerAd);
+      expect(
+        find.descendant(of: easyBannerFinder, matching: find.byType(SafeArea)),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('adaptive banner omits SafeArea when useSafeArea is false', (
+      tester,
+    ) async {
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      await AdFlow.instance.initialize();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: EasyBannerAd(useSafeArea: false)),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final easyBannerFinder = find.byType(EasyBannerAd);
+      expect(easyBannerFinder, findsOneWidget);
+      expect(
+        find.descendant(of: easyBannerFinder, matching: find.byType(SafeArea)),
+        findsNothing,
+      );
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('adaptive banner wraps with SafeArea by default', (
+      tester,
+    ) async {
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      await AdFlow.instance.initialize();
+
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: EasyBannerAd())),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final easyBannerFinder = find.byType(EasyBannerAd);
+      expect(
+        find.descendant(of: easyBannerFinder, matching: find.byType(SafeArea)),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+  });
+
   group('EasyBannerAd ads disabled on init', () {
     testWidgets('does not load when ads disabled from start', (tester) async {
       await AdsEnabledManager.instance.disableAds();


### PR DESCRIPTION
✅ Problem: Adaptive banners sometimes show extra black space on certain screen sizes.

💡 Solution:
- Made SafeArea optional in EasyBannerAd to prevent extra black space
- Tested in example project on multiple screen sizes

⚠️ Breaking changes: None